### PR TITLE
feat(cli): add user context to MonitoringService

### DIFF
--- a/src/browser/BrowserMonitoringService.test.ts
+++ b/src/browser/BrowserMonitoringService.test.ts
@@ -1,7 +1,10 @@
 import { datadogLogs } from '@datadog/browser-logs';
 
+import { userSymbol } from '../shared/userSymbol';
+
 import { BrowserMonitoringService } from './BrowserMonitoringService';
 
+//  TODO: find a way to easily reset and extend this mock in beforeEach blocks to mock only needed part
 jest.mock('@datadog/browser-logs', () => ({
   datadogLogs: {
     logger: {
@@ -11,6 +14,9 @@ jest.mock('@datadog/browser-logs', () => ({
       error: jest.fn(),
     },
     init: jest.fn(),
+    setUser: jest.fn(),
+    getUser: jest.fn(),
+    clearUser: jest.fn(),
   },
 }));
 
@@ -123,5 +129,128 @@ describe('BrowserMonitoringService', () => {
     expect(datadogLogs.logger.debug).toHaveBeenCalledWith(message, context);
     browserMonitoringService.warn(message, context);
     expect(datadogLogs.logger.warn).toHaveBeenCalledWith(message, context);
+  });
+
+  describe('user context', () => {
+    const message = 'message';
+    const context = { key: 'value' };
+    const user = {
+      email: 'john@google.com',
+    };
+
+    describe('with local logger', () => {
+      let consoleInfoSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation();
+      });
+
+      afterEach(() => {
+        consoleInfoSpy.mockRestore();
+      });
+
+      it('logs user context if present', function () {
+        const browserMonitoringService = new BrowserMonitoringService();
+        browserMonitoringService.userContext.setUser(user);
+        browserMonitoringService.info(message);
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message, {
+          [userSymbol]: user,
+        });
+      });
+
+      it('logs updated user context', function () {
+        const newUser = {
+          email: 'james@google.com',
+        };
+        const browserMonitoringService = new BrowserMonitoringService();
+        browserMonitoringService.userContext.setUser(user);
+        browserMonitoringService.info(message);
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message, {
+          [userSymbol]: user,
+        });
+
+        browserMonitoringService.userContext.setUser(newUser);
+        browserMonitoringService.info(message);
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message, {
+          [userSymbol]: newUser,
+        });
+      });
+
+      it('allow context property manipulations', function () {
+        const browserMonitoringService = new BrowserMonitoringService();
+        const propName = 'name';
+        const propValue = 'John';
+        const userWithExtraProp = {
+          ...user,
+          [propName]: propValue,
+        };
+        browserMonitoringService.userContext.setUser(userWithExtraProp);
+        browserMonitoringService.userContext.removeUserProperty(propName);
+
+        browserMonitoringService.info(message);
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message, {
+          [userSymbol]: user,
+        });
+
+        browserMonitoringService.userContext.setUserProperty(
+          propName,
+          propValue,
+        );
+        browserMonitoringService.info(message);
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message, {
+          [userSymbol]: userWithExtraProp,
+        });
+      });
+
+      it("don't log user context if it is cleared", () => {
+        const browserMonitoringService = new BrowserMonitoringService();
+
+        browserMonitoringService.userContext.setUser(user);
+
+        browserMonitoringService.info(message);
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message, {
+          [userSymbol]: user,
+        });
+
+        browserMonitoringService.userContext.clearUser();
+
+        browserMonitoringService.info(message);
+        expect(consoleInfoSpy).toHaveBeenCalledWith(message);
+      });
+    });
+
+    describe('with remote logger', () => {
+      it('uses remote logger context', function () {
+        const browserMonitoringService = new BrowserMonitoringService({
+          serviceName: 'serviceName',
+          serviceEnv: 'serviceEnv',
+          serviceVersion: 'serviceVersion',
+          authToken: 'authToken',
+        });
+
+        browserMonitoringService.userContext.setUser(user);
+        expect(datadogLogs.setUser).toHaveBeenCalledWith(user);
+        browserMonitoringService.userContext.clearUser();
+        expect(datadogLogs.clearUser).toHaveBeenCalled();
+      });
+
+      it("doesn't put user into context", function () {
+        (datadogLogs.getUser as jest.Mock).mockReturnValueOnce(user);
+        const browserMonitoringService = new BrowserMonitoringService({
+          serviceName: 'serviceName',
+          serviceEnv: 'serviceEnv',
+          serviceVersion: 'serviceVersion',
+          authToken: 'authToken',
+        });
+
+        browserMonitoringService.info(message, context);
+        expect(datadogLogs.logger.info).toHaveBeenCalledWith(message, context);
+      });
+    });
   });
 });

--- a/src/browser/BrowserMonitoringService.ts
+++ b/src/browser/BrowserMonitoringService.ts
@@ -1,10 +1,10 @@
 import { datadogLogs } from '@datadog/browser-logs';
 import { LogsInitConfiguration } from '@datadog/browser-logs/src/domain/configuration';
 
-import {
-  MonitoringService,
-  RemoteMonitoringServiceParams,
-} from '../shared/MonitoringService';
+import { MonitoringService } from '../shared/MonitoringService';
+import { RemoteMonitoringServiceParams } from '../shared/RemoteMonitoringServiceParams';
+
+import { DatadogLoggerWrapper } from './DatadogLoggerWrapper';
 
 type RemoteMonitoringServiceConfig = Partial<LogsInitConfiguration>;
 
@@ -16,13 +16,13 @@ export class BrowserMonitoringService extends MonitoringService {
     super(remoteMonitoringServiceParams, remoteMonitoringServiceConfig);
   }
 
-  initRemoteLogger(
+  initRemoteMonitoring(
     remoteMonitoringServiceParams: RemoteMonitoringServiceParams,
     remoteMonitoringServiceConfig?: RemoteMonitoringServiceConfig,
   ) {
     const { serviceName, serviceVersion, serviceEnv, authToken } =
       remoteMonitoringServiceParams ?? {};
-    const ddLogger = datadogLogs.logger;
+    const logger = new DatadogLoggerWrapper(datadogLogs.logger);
     datadogLogs.init({
       clientToken: authToken ?? '',
       service: serviceName,
@@ -32,6 +32,9 @@ export class BrowserMonitoringService extends MonitoringService {
       ...remoteMonitoringServiceConfig,
     });
 
-    return ddLogger;
+    return {
+      logger,
+      userContext: datadogLogs,
+    };
   }
 }

--- a/src/browser/DatadogLoggerWrapper.ts
+++ b/src/browser/DatadogLoggerWrapper.ts
@@ -1,0 +1,46 @@
+import { Logger as DatadogLogger } from '@datadog/browser-logs';
+
+import { Logger, LogLevel } from '../shared/Logger';
+import { userSymbol } from '../shared/userSymbol';
+
+export class DatadogLoggerWrapper implements Logger {
+  private datadogLogger: DatadogLogger;
+
+  constructor(datadogLogger: DatadogLogger) {
+    this.datadogLogger = datadogLogger;
+  }
+
+  log(
+    level: LogLevel,
+    ...args: [message: string, context?: object, error?: Error]
+  ) {
+    const [message, context, ...otherArgs] = args;
+
+    // remove userinfo from context for datadog logger, because datadog handles user under the hood
+    // other possibility would be to use datadog `usr` key in the context, but it will conflic with
+    // under-the-hood implementation
+    if (context && userSymbol in context) {
+      // eslint-disable-next-line no-unused-vars
+      const { [userSymbol]: _, ...contextWithoutUser } = context;
+      this.datadogLogger[level](message, contextWithoutUser, ...otherArgs);
+    }
+
+    this.datadogLogger[level](...args);
+  }
+
+  debug(...args: [message: string, context?: object]) {
+    this.log('debug', ...args);
+  }
+
+  info(...args: [message: string, context?: object]) {
+    this.log('info', ...args);
+  }
+
+  warn(...args: [message: string, context?: object]) {
+    this.log('warn', ...args);
+  }
+
+  error(...args: [message: string, context?: object, error?: Error]) {
+    this.log('error', ...args);
+  }
+}

--- a/src/browser/LocalUserContext.ts
+++ b/src/browser/LocalUserContext.ts
@@ -1,0 +1,32 @@
+import { User } from '../shared/User';
+
+import { UserContext } from './UserContext';
+
+export class LocalUserContext implements UserContext {
+  user: User | undefined;
+
+  setUser(user: User) {
+    this.user = user;
+  }
+
+  getUser() {
+    return this.user;
+  }
+
+  clearUser() {
+    this.user = undefined;
+  }
+
+  removeUserProperty(property: string) {
+    // eslint-disable-next-line no-unused-vars
+    const { [property]: _, ...user } = this.user ?? {};
+    this.user = user;
+  }
+
+  setUserProperty(property: string, value: unknown) {
+    this.user = {
+      ...this.user,
+      [property]: value,
+    };
+  }
+}

--- a/src/browser/UserContext.ts
+++ b/src/browser/UserContext.ts
@@ -1,0 +1,13 @@
+import { User } from '../shared/User';
+
+export interface UserContext {
+  setUser(user: User): void;
+
+  getUser(): User | undefined;
+
+  clearUser(): void;
+
+  removeUserProperty(property: string): void;
+
+  setUserProperty(property: string, value: unknown): void;
+}

--- a/src/server/ServerMonitoringService.ts
+++ b/src/server/ServerMonitoringService.ts
@@ -2,11 +2,10 @@ import 'pino-datadog-transport';
 import deepMerge from 'deepmerge';
 import pino, { LoggerOptions, TransportBaseOptions } from 'pino';
 
-import {
-  MonitoringService,
-  RemoteMonitoringServiceParams,
-} from '../shared/MonitoringService';
+import { MonitoringService } from '../shared/MonitoringService';
 import { ConsoleLogger } from '../shared/ConsoleLogger';
+import { RemoteMonitoringServiceParams } from '../shared/RemoteMonitoringServiceParams';
+import { LocalUserContext } from '../browser/LocalUserContext';
 
 import { getLoggingFunction } from './getLoggingFunction';
 import { PinoWrapper } from './PinoWrapper';
@@ -36,7 +35,7 @@ export class ServerMonitoringService extends MonitoringService {
     super(remoteMonitoringServiceParams, remoteMonitoringServiceConfig);
   }
 
-  initRemoteLogger(
+  initRemoteMonitoring(
     remoteMonitoringServiceParams: RemoteMonitoringServiceParams,
     remoteMonitoringServiceConfig: RemoteMonitoringServiceConfig = {},
   ) {
@@ -78,7 +77,12 @@ export class ServerMonitoringService extends MonitoringService {
     );
     const pinoLogger = pino(finalLoggerOptions, transport);
 
-    return new PinoWrapper(pinoLogger);
+    const logger = new PinoWrapper(pinoLogger);
+
+    return {
+      logger,
+      userContext: new LocalUserContext(),
+    };
   }
 
   overrideLogger(unknownLogger: UnknownLogger) {

--- a/src/server/initServerMonitoring.ts
+++ b/src/server/initServerMonitoring.ts
@@ -1,4 +1,4 @@
-import { RemoteMonitoringServiceParams } from '../shared/MonitoringService';
+import { RemoteMonitoringServiceParams } from '../shared/RemoteMonitoringServiceParams';
 
 import {
   RemoteMonitoringServiceConfig,

--- a/src/shared/Logger.ts
+++ b/src/shared/Logger.ts
@@ -7,3 +7,5 @@ export interface Logger {
 
   error(message: string, context?: object, error?: Error): void;
 }
+
+export type LogLevel = keyof Logger;

--- a/src/shared/RemoteMonitoringServiceParams.ts
+++ b/src/shared/RemoteMonitoringServiceParams.ts
@@ -1,0 +1,6 @@
+export interface RemoteMonitoringServiceParams {
+  serviceName?: string;
+  serviceVersion?: string;
+  serviceEnv?: string;
+  authToken?: string;
+}

--- a/src/shared/User.ts
+++ b/src/shared/User.ts
@@ -1,0 +1,7 @@
+export interface User {
+  id?: string | undefined;
+  email?: string | undefined;
+  name?: string | undefined;
+
+  [key: string]: unknown;
+}

--- a/src/shared/userSymbol.ts
+++ b/src/shared/userSymbol.ts
@@ -1,0 +1,1 @@
+export const userSymbol = Symbol('user');


### PR DESCRIPTION
## Description

Added `.userContext` object to MonitoringService to be able to provide and persist user.

## Motivation and Context

Why is this change required?
- it helps better track user actions, also it reexpose datadog user API, which was hidden before

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
