### PR TITLE
fix: update dd trace to 4.20 (nice)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@datadog/browser-logs": "^5.2.0",
-        "dd-trace": "^4.18.0",
+        "dd-trace": "^4.20.0",
         "deepmerge": "^4.3.1",
         "pino": "^8.16.1",
         "pino-datadog-transport": "^1.3.2"
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.3.tgz",
-      "integrity": "sha512-u/bBPNx0w8Bq+I+30enI99Ua2WPbVLkANGNyQNjW4tz2PHyeGI++HyzZV+fGm0YSy41FuHZq9EWP3SSDz/eSVw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
@@ -4721,22 +4721,30 @@
         "node": ">=14"
       }
     },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/dd-trace": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.18.0.tgz",
-      "integrity": "sha512-rycfmSIshWcphYavFE4iozpu0QbnLpXiUuan+Ft3mvPFe+wYgqY8agu+goRNGAXZYFXNLk7jVN5OTXYO2AMJtQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.20.0.tgz",
+      "integrity": "sha512-y7IDLSSt6nww6zMdw/I8oLdfgOQADIOkERCNdfSzlBrXHz5CHimEOFfsHN87ag0mn6vusr06aoi+CQRZSNJz2g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@datadog/native-appsec": "^4.0.0",
+        "@datadog/native-appsec": "4.0.0",
         "@datadog/native-iast-rewriter": "2.2.1",
-        "@datadog/native-iast-taint-tracking": "1.6.3",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
         "@datadog/native-metrics": "^2.0.0",
         "@datadog/pprof": "4.0.1",
         "@datadog/sketches-js": "^2.1.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
+        "dc-polyfill": "^0.1.2",
         "ignore": "^5.2.4",
         "import-in-the-middle": "^1.4.2",
         "int64-buffer": "^0.1.9",
@@ -4756,6 +4764,7 @@
         "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
+        "pprof-format": "^2.0.7",
         "protobufjs": "^7.2.4",
         "retry": "^0.13.1",
         "semver": "^7.5.4"
@@ -5102,14 +5111,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^5.2.0",
-    "dd-trace": "^4.18.0",
+    "dd-trace": "^4.20.0",
     "deepmerge": "^4.3.1",
     "pino": "^8.16.1",
     "pino-datadog-transport": "^1.3.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Updated dd-trace dependency to ^4.20. We see a lot of spam errors that are related to how Next.js middleware works internally. Should be fixed after dd-trace update, since they fixed the issue in issue linked below.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Related Issue

https://github.com/DataDog/dd-trace-js/issues/3682

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

`npm run test`

### Checklist

- This is a breaking change:
  - [ ] Yes
  - [x] No
- Will this release a new version:
  - [x] Yes
  - [ ] No
